### PR TITLE
docs: added readme info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,152 @@
-# React + Vite
+**Status**: Active Development | **Last Updated**: April 2026
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+# IS-302 — Praksisdokumentasjon
 
-Currently, two official plugins are available:
+Nettside for dokumentasjon av praksisemnet IS-302 ved Universitetet i Agder.
+Gruppen presenterer seg selv, oppgaven, fremdrift og refleksjoner gjennom en interaktiv SPA.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+## 1. Demo
 
-## React Compiler
+> [!IMPORTANT]
+> <details>
+> <summary style="font-size: 14px; font-weight: bold">Live-side</summary>
+>
+> Kjøres lokalt via Vite — se oppsett nedenfor.
+>
+> </details>
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+---
 
-## Expanding the ESLint configuration
+## 2. Technical Stack
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+### Frontend
+| Component        | Version  | Usage                                              |
+|------------------|----------|----------------------------------------------------|
+| React            | ^18.x    | UI-bibliotek med komponentbasert arkitektur        |
+| Vite             | ^6.x     | Byggeverktøy og dev-server med HMR                 |
+| React Router v6  | ^6.x     | Klientside routing mellom sider                    |
+| GSAP 3           | ^3.x     | Scroll-trigget animasjoner og side-transitions     |
+| TypeScript       | —        | Ikke i bruk, prosjektet bruker JSX                 |
+
+### Datalagring
+| Komponent      | Usage                                                    |
+|----------------|----------------------------------------------------------|
+| localStorage   | CRUD-lagring for Dagbok, Status 1/2 og Refleksjon        |
+
+---
+
+## 3. Sidestruktur
+
+| Rute          | Komponent         | Innhold                                      |
+|---------------|-------------------|----------------------------------------------|
+| `/`           | `Home.jsx`        | Hero-seksjon med intro og call-to-action      |
+| `/om-oss`     | `OmOss.jsx`       | Introduksjonsvideo og tidligere prosjekter    |
+| `/oppgave`    | `Oppgave.jsx`     | Beskrivelse av praksisoppgaven                |
+| `/team`       | `Team.jsx`        | Oversikt over gruppemedlemmer                 |
+| `/status-1`   | `Status1.jsx`     | Redigerbar statusrapport 1 (localStorage)     |
+| `/status-2`   | `Status2.jsx`     | Redigerbar statusrapport 2 (localStorage)     |
+| `/dagbok`     | `Dagbok.jsx`      | Ukelogg med add/edit/delete (localStorage)    |
+| `/refleksjon` | `Refleksjon.jsx`  | Redigerbare refleksjonsnotater (localStorage) |
+
+---
+
+## 4. Arkitektur
+
+```
+src/
+├── components/
+│   ├── Navbar.jsx          # Fast navigasjonsbar med glass-blur og mobil-drawer
+│   ├── Footer.jsx          # Footer med nav-lenker og brand
+│   ├── TeamCard.jsx        # Kort for hvert gruppemedlem
+│   └── EditablePage.jsx    # Gjenbrukbar CRUD-komponent (Status, Refleksjon)
+│
+├── pages/
+│   ├── Home.jsx            # Landingsside med GSAP-animert hero
+│   ├── OmOss.jsx           # Om oss — video + prosjektkort
+│   ├── Oppgave.jsx         # Praksisoppgave
+│   ├── Team.jsx            # 5-kolonne grid med teamkort
+│   ├── Dagbok.jsx          # Fullstendig CRUD-dagbok med localStorage
+│   ├── Status1.jsx         # Bruker EditablePage, key: status1Entries
+│   ├── Status2.jsx         # Bruker EditablePage, key: status2Entries
+│   └── Refleksjon.jsx      # Bruker EditablePage, key: reflectionEntries
+│
+├── data/
+│   ├── teamMembers.js      # Array med info om alle 5 gruppemedlemmer
+│   ├── projects.js         # Array med tidligere prosjekter (Om oss-siden)
+│   ├── navLinks.js         # Navigasjonslenker brukt i Navbar
+│   └── diaryEntries.js     # Standard-oppføringer for Dagbok
+│
+├── hooks/
+│   └── useReveal.js        # GSAP scroll-trigger hook for entrance-animasjoner
+│
+└── index.css               # Design tokens, reset og globale utilities
+```
+
+**Dataflyt (CRUD-sider):**
+1. Bruker åpner Status/Dagbok/Refleksjon
+2. `EditablePage` / `Dagbok` leser fra `localStorage` ved oppstart
+3. Add/edit/delete oppdaterer React-state
+4. `useEffect` synkroniserer state til `localStorage` automatisk
+5. "Lagret"-flash bekrefter vellykket lagring
+
+---
+
+## 5. Designsystem
+
+| Token          | Verdi       | Bruk                              |
+|----------------|-------------|-----------------------------------|
+| `--ink`        | `#0a0a0a`   | Sidebakgrunn                      |
+| `--ash`        | `#1c1c1e`   | Kortbakgrunn                      |
+| `--accent`     | `#e8ff47`   | Lime-aksent — knapper, aktive lenker |
+| `--snow`       | `#f5f5f7`   | Overskrifter                      |
+| `--silver`     | `#8e8e93`   | Sekundærtekst                     |
+| `--font-heading` | Syne      | Alle overskrifter                 |
+| `--font-body`  | DM Sans     | Brødtekst og UI                   |
+| `--font-mono`  | JetBrains Mono | Tags, labels, kode              |
+
+---
+
+## 6. Oppsett
+
+### Klon repository
+
+```bash
+git clone https://github.com/iverkroken/IS-302.git
+cd IS-302
+```
+
+### Installer avhengigheter
+
+```bash
+npm install
+```
+
+### Start dev-server
+
+```bash
+npm run dev
+```
+
+Åpnes på f.eks:`http://localhost:5173` (eller neste ledige port).
+
+### Bygg for produksjon
+
+```bash
+npm run build
+```
+
+---
+
+## 7. Gruppemedlemmer
+
+| Navn                  | LinkedIn |
+|-----------------------|----------|
+| Iver Kroken           | [linkedin.com/in/iver-kroken](https://www.linkedin.com/in/iver-kroken/) |
+| Tobias Olsen Nodland  | [linkedin.com/in/tobias-olsen-nodland](https://www.linkedin.com/in/tobias-olsen-nodland-44b03a3a0/) |
+| Sivert Svanes Sæstad  | [linkedin.com/in/sivert-svanes-sæstad](https://www.linkedin.com/in/sivert-svanes-s%C3%A6stad-615aa1262/) |
+| Eira Bitnes Vikestøl  | [linkedin.com/in/eira-bitnes-vikestøl](https://www.linkedin.com/in/eira-bitnes-vikst%C3%B8l-185136355/) |
+| Oda Elise Aanestad    | [linkedin.com/in/oda-elise-aanestad](https://www.linkedin.com/in/oda-elise-aanestad-857206351/) |
+
+---
+
+*Universitetet i Agder — IS-302 Praksis, 2026*


### PR DESCRIPTION
This pull request significantly updates the `README.md` to provide comprehensive and project-specific documentation for the IS-302 practice documentation website. The new README replaces the default template with detailed sections on the project's purpose, technical stack, architecture, design system, setup instructions, and team members.

Key improvements and additions:

**Project Overview & Structure**
* Replaced the default Vite/React template documentation with a custom introduction describing the IS-302 documentation site, its purpose, and how it is used by the group.
* Added a detailed table outlining the site's route structure and the corresponding React components, clarifying the navigation and content organization.
* Included an architectural diagram of the `src/` folder, describing the purpose of each major file and directory.

**Technical Stack & Data Flow**
* Listed all major frontend technologies and libraries used, with their versions and roles, as well as the approach to client-side data storage using `localStorage`.
* Described the data flow for editable pages (CRUD operations), including how state is synchronized with `localStorage`.

**Design System & Setup**
* Documented the project's design tokens (colors, fonts) and their usage throughout the UI.
* Provided clear setup instructions for cloning the repo, installing